### PR TITLE
Correct a bug in the last commit.

### DIFF
--- a/sqlite.js
+++ b/sqlite.js
@@ -137,7 +137,7 @@ function SQLTransactionSync(db, txCallback, errCallback, successCallback) {
 
   if (!this.rolledBack && successCallback) {
     successCallback(this);
-  } else if (errCallback) {
+  } else if (this.rolledBack && errCallback) {
     errCallback(this);
   }
 }


### PR DESCRIPTION
Appologies.

In the last version, if the success callback is absent, the error callback would be called even if there was no rollback.
